### PR TITLE
Fix build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ group = "kr.heartpattern"
 version = "1.0.0-SNAPSHOT"
 
 repositories {
-    maven("https://maven.heartpattern.kr/repository/maven-public/")
+    maven("https://repo.heartpattern.io/repository/maven-public/")
 }
 
 dependencies {
@@ -41,8 +41,8 @@ publishing {
                 "https://maven.heartpattern.kr/repository/maven-public-releases/"
         ) {
             credentials {
-                username = project.properties["nexusUser"] as String
-                password = project.properties["nexusPassword"] as String
+                username = project.properties["nexusUser"] as String?
+                password = project.properties["nexusPassword"] as String?
             }
         }
     }


### PR DESCRIPTION
This PR fixes the build.



There is still an issue when using 1 thread, the thread pool rejects adding new tasks:
```
60289129 rejected from java.util.concurrent.ThreadPoolExecutor@335992b3[Shutting down, pool size = 1, active threads = 1, queued tasks = 5543, completed tasks = 2611]
        at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
        at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
        at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
        at java.util.concurrent.Executors$DelegatedExecutorService.execute(Executors.java:668)
        at kr.heartpattern.exhibitionism.ExhibitionismKt$transform$2.run(Exhibitionism.kt:41)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

A workaround is using a thousand threads (probably not the best workaround)

Thanks

Moritz